### PR TITLE
Added a repeat group time decay factor and a stats csv export option

### DIFF
--- a/config/mappings_and_weights.yml
+++ b/config/mappings_and_weights.yml
@@ -1,24 +1,26 @@
 ---
   team_mappings:
-    Community Support: 100
-    Community: 90
-    Marketing: 80
-    Communications: 70
-    Operations: 50
-    Product: 40
+    Engineering: 0
+    Data: 10
+    Product: 20
     Design: 30
-    Engineering: 20
-    Data: 0
+    Marketing: 40
+    Outreach: 50
+    Community Support: 60
+    Integrity: 70
+    Communications: 80
+    Operations: 90
+    Exec: 110
   specialty_mappings:
     Backend: 0
-    Data: 20
-    Frontend: 30
-    Mobile: 50
-    Finance: 100
-    Legal: 120
+    ST: 50
+    Frontend: 10
+    Mobile: 20
   weights:
     table: 0.4
     days_here: 0.2
     team: 0.9
     specialty: 0.1
   min_lunch_group_size: 5
+  min_group_score: 0.0001
+  time_decay_constant: 80.0

--- a/lib/lunch_roulette.rb
+++ b/lib/lunch_roulette.rb
@@ -15,7 +15,7 @@ require 'lunch_roulette/output'
 
 class LunchRoulette
 
-  attr_reader :results, :staff
+  attr_reader :results, :staff, :all_valid_sets
 
   def initialize(*args)
     LunchRoulette::Config.new
@@ -30,6 +30,7 @@ class LunchRoulette
       o.on('-l', '--least-varied-sets L', 'Number of least varied sets to generate (default 0)') {|i| options[:least_varied_sets] = i.to_i }
       o.on('-v', '--verbose', 'Verbose output') { options[:verbose_output] = true }
       o.on('-d', '--dont-write', "Don't write to files") { options[:dont_write] = true }
+      o.on('-s', '--output-stats', "Output a csv of stats for all valid generated sets") { options[:output_stats] = true }
       o.on('-h', '--help', 'Print this help') { puts o; exit }
       o.parse!
     end
@@ -82,6 +83,7 @@ class LunchRoulette
       top: candidates.sort{|a,b| b.score <=> a.score }.first(config.options[:most_varied_sets].to_i),
       bottom: candidates.sort{|a,b| a.score <=> b.score }.first(config.options[:least_varied_sets].to_i)
     }
+    @all_valid_sets = candidates
   end
 
   protected
@@ -100,12 +102,12 @@ end
 l = LunchRoulette.new(ARGV)
 l.spin!
 
-o = LunchRoulette::Output.new(l.results)
+o = LunchRoulette::Output.new(l.results, l.all_valid_sets)
 o.get_results
+o.get_stats_csv if o.config.options[:output_stats]
 
 if l.results[:top].size > 0 || l.results[:bottom].size > 0
   o.get_new_staff_csv(l.staff)
 else
   puts "No valid sets generated, sorry."
 end
-

--- a/lib/lunch_roulette/config.rb
+++ b/lib/lunch_roulette/config.rb
@@ -15,6 +15,14 @@ class LunchRoulette
       @@options[:min_lunch_group_size] || @@config['min_lunch_group_size']
     end
 
+    def self.min_group_score
+      @@config['min_group_score']
+    end
+
+    def self.time_decay_constant
+      @@config['time_decay_constant']
+    end
+
     def self.match_thresholds
       (2..min_lunch_group_size)
     end

--- a/lib/lunch_roulette/lunch_set.rb
+++ b/lib/lunch_roulette/lunch_set.rb
@@ -7,7 +7,7 @@ class LunchRoulette
       # Shuffle our incoming people:
       @lunchers = staff.shuffle
       @groups = generate_groups
-      @score = @groups.map{ |g| g.sum_score }.sum
+      @score = @groups.map{ |g| g.score}.sum
       @previous_lunches = {}
       previous_lunch_stats
       @valid = valid_set?
@@ -63,23 +63,10 @@ class LunchRoulette
 
     def valid_set?
       @valid = true
-
-      # Are there any groups that have i people who have had lunch previously?
-      i = [3, config.min_lunch_group_size].min
-
-      if @previous_lunches[i] > 0
-        @valid = false
+      # Are there any groups that are individually too low-scoring to allow?
+      groups.each do |group|
+        @valid = false if group.score < config.min_group_score
       end
-
-      # Are two execs having lunch with each other? (Lunch 0 is the permanent exec lunch)
-      groups.map do |group|
-        group.previous_lunches.values.map do |previous_lunch|
-          if previous_lunch.to_a.flatten.include? 0
-            @valid = false
-          end
-        end
-      end
-
       # Are there any people with the same specialty in the same group?
       groups.map do |group|
         specialities = group.people.map{|person| person.specialty }.compact


### PR DESCRIPTION
### Time decay

The main thing I changed was the way LR handles repeated subgroups over time. Previously, all trios who dined together once were forbidden from dining in the same group ever again. On the other hand, any pair who dined together previously would be free to dine together again at any time. This led to a skewed distribution of valid lunch sets over time, as more and more of the high-scoring trios were used up. Moreover, repeated lunch pairs were happening regularly, which was defeating part of the purpose of dining with new faces. 

I simply got rid of the "no repeated trios" rule, and instead added a time decay factor for all subgroups. This calculates an approximate time difference between current and past lunch groups, based simply on the difference in id value. It then applies a decay curve to the time difference, and uses it to penalize any candidate lunch group that contains recent repeated subgroups. 

In general, with this change trios that occurred long ago are welcome to dine again, but any subgroup that ate together recently will very likely not convene again in the short term. 

A decay parameter in `mappings_and_weights.yml` can be adjusted as needed to change the rate of decay of the penalty. A higher decay parameter equates to a slower rate of decay for the repetition penalty. So if you want previous groups to never dine together again for a long time, then make the parameter really big.
### Stats output

I added a stats output command line argument which, if enabled, writes a csv file with the score breakdowns of all valid lunch sets. I used this in diagnosing the shortcomings of the old LR algorithm while developing this new version.
### Minimum group score

I added an additional parameter to `mappings_and_weights.yml` which sets a minimum allowable group score. Since LR chooses its optimum lunch set based on the sum of scores across all its groups, it is possible for a winning set to contain a few high-scoring groups but one or two dismal ones. With the new decay factor this can equate to having one or two groups that are highly repetitive from recent lunches. I added the minimum group score parameter to make sure that no single group could fall too low in the optimal set. 
